### PR TITLE
Fix all unit tests

### DIFF
--- a/SkyEditor.ROMEditor.UI.WPF/SkyEditor.ROMEditor.UI.WPF.vbproj
+++ b/SkyEditor.ROMEditor.UI.WPF/SkyEditor.ROMEditor.UI.WPF.vbproj
@@ -75,10 +75,10 @@
       <HintPath>..\packages\DotNet3dsToolkit.2.0.0-CI51\lib\net462\DotNet3dsToolkit.dll</HintPath>
     </Reference>
     <Reference Include="DotNetNdsToolkit, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetNdsToolkit.2.0.0-CI114\lib\net462\DotNetNdsToolkit.dll</HintPath>
+      <HintPath>..\packages\DotNetNdsToolkit.2.0.0-CI117\lib\net462\DotNetNdsToolkit.dll</HintPath>
     </Reference>
-    <Reference Include="DSPatcher, Version=1.2.0.109, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DS-ROM-Patcher.1.2.0-CI109\lib\net462\DSPatcher.exe</HintPath>
+    <Reference Include="DSPatcher, Version=1.2.0.111, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DS-ROM-Patcher.1.2.0-CI111\lib\net462\DSPatcher.exe</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.AvalonEdit, Version=5.0.3.0, Culture=neutral, PublicKeyToken=9cc39be672370310, processorArchitecture=MSIL">
       <HintPath>..\packages\AvalonEdit.5.0.3\lib\Net40\ICSharpCode.AvalonEdit.dll</HintPath>

--- a/SkyEditor.ROMEditor.UI.WPF/packages.config
+++ b/SkyEditor.ROMEditor.UI.WPF/packages.config
@@ -5,8 +5,8 @@
   <package id="Crc32.NET" version="1.2.0" targetFramework="net462" />
   <package id="DotNet3dsSoundtrackConverter" version="1.1.2-CI106" targetFramework="net462" />
   <package id="DotNet3dsToolkit" version="2.0.0-CI51" targetFramework="net462" />
-  <package id="DotNetNdsToolkit" version="2.0.0-CI114" targetFramework="net462" />
-  <package id="DS-ROM-Patcher" version="1.2.0-CI109" targetFramework="net462" />
+  <package id="DotNetNdsToolkit" version="2.0.0-CI117" targetFramework="net462" />
+  <package id="DS-ROM-Patcher" version="1.2.0-CI111" targetFramework="net462" />
   <package id="Extended.Wpf.Toolkit" version="3.0" targetFramework="net46" />
   <package id="ListViewDragDropManager" version="1.2.0" targetFramework="net46" />
   <package id="MediaToolkit" version="1.2.2-CI5" targetFramework="net46" />

--- a/SkyEditor.ROMEditor.Windows/SkyEditor.ROMEditor.Windows.vbproj
+++ b/SkyEditor.ROMEditor.Windows/SkyEditor.ROMEditor.Windows.vbproj
@@ -93,10 +93,10 @@
       <HintPath>..\packages\DotNet3dsToolkit.2.0.0-CI51\lib\net462\DotNet3dsToolkit.dll</HintPath>
     </Reference>
     <Reference Include="DotNetNdsToolkit, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetNdsToolkit.2.0.0-CI114\lib\net462\DotNetNdsToolkit.dll</HintPath>
+      <HintPath>..\packages\DotNetNdsToolkit.2.0.0-CI117\lib\net462\DotNetNdsToolkit.dll</HintPath>
     </Reference>
-    <Reference Include="DSPatcher, Version=1.2.0.109, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DS-ROM-Patcher.1.2.0-CI109\lib\net462\DSPatcher.exe</HintPath>
+    <Reference Include="DSPatcher, Version=1.2.0.111, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DS-ROM-Patcher.1.2.0-CI111\lib\net462\DSPatcher.exe</HintPath>
     </Reference>
     <Reference Include="LanguageStringPatcher, Version=1.0.0.5, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\LanguageStringPatcher.1.0.1\lib\net46\LanguageStringPatcher.exe</HintPath>

--- a/SkyEditor.ROMEditor.Windows/packages.config
+++ b/SkyEditor.ROMEditor.Windows/packages.config
@@ -3,8 +3,8 @@
   <package id="Crc32.NET" version="1.2.0" targetFramework="net462" />
   <package id="DotNet3dsSoundtrackConverter" version="1.1.2-CI106" targetFramework="net462" />
   <package id="DotNet3dsToolkit" version="2.0.0-CI51" targetFramework="net462" />
-  <package id="DotNetNdsToolkit" version="2.0.0-CI114" targetFramework="net462" />
-  <package id="DS-ROM-Patcher" version="1.2.0-CI109" targetFramework="net462" />
+  <package id="DotNetNdsToolkit" version="2.0.0-CI117" targetFramework="net462" />
+  <package id="DS-ROM-Patcher" version="1.2.0-CI111" targetFramework="net462" />
   <package id="LanguageStringPatcher" version="1.0.1" targetFramework="net46" />
   <package id="MediaToolkit" version="1.2.2-CI5" targetFramework="net46" />
   <package id="Message-FARC-Patcher" version="1.0.2" targetFramework="net46" />

--- a/SkyEditor.ROMEditor/MysteryDungeon/Explorers/item_p.vb
+++ b/SkyEditor.ROMEditor/MysteryDungeon/Explorers/item_p.vb
@@ -157,7 +157,7 @@ Namespace MysteryDungeon.Explorers
         End Class
 
         Public Sub New()
-            AutoAddSir0HeaderRelativePointers = True
+
         End Sub
 
         Public Overrides Async Function OpenFile(Filename As String, Provider As IIOProvider) As Task Implements IOpenableFile.OpenFile
@@ -174,6 +174,14 @@ Namespace MysteryDungeon.Explorers
         End Sub
 
         Public Overrides Async Function Save(Destination As String, provider As IIOProvider) As Task
+            'Let the Sir0 class automatically handle the relative pointers in the SIR0 header
+            AutoAddSir0HeaderRelativePointers = True
+            AutoAddSir0SubHeaderRelativePointers = True
+
+            'There are no pointers in this particular file type
+            RelativePointers.Clear()
+            SubHeaderRelativePointers.Clear()
+
             Dim out As New List(Of Byte)
 
             For Each item In Items

--- a/Tests/SkyEditor.ROMEditor.IntegrationTests/BRTUTests.vb
+++ b/Tests/SkyEditor.ROMEditor.IntegrationTests/BRTUTests.vb
@@ -26,25 +26,6 @@ Imports SkyEditor.ROMEditor.Utilities
         Return Directory.Exists(romDir)
     End Function
 
-    Public Shared Sub UnpackFiles(provider As IIOProvider)
-        Try
-            Using md5 As New MD5CryptoServiceProvider
-                Dim hash = md5.ComputeHash(My.Resources.brt_u)
-                If Not hash.SequenceEqual(My.Resources.BRT_U_MD5) Then
-                    Assert.Inconclusive("Incorrect test ROM specified.  Should be a trimmed North America PMD: Blue Rescue Team ROM.")
-                End If
-            End Using
-
-            provider.WriteAllBytes(romFilename, My.Resources.brt_u)
-            Using nds As New NdsRom
-                nds.OpenFile(romFilename, provider).Wait()
-                nds.Unpack(romDir, provider).Wait()
-            End Using
-        Catch ex As Exception
-            Assert.Inconclusive("Failed to set up.  Exception message: " & ex.Message)
-        End Try
-    End Sub
-
     Public Shared Sub CleanupFiles(provider As IIOProvider)
         If provider.FileExists(romFilename) Then
             provider.DeleteFile(romFilename)
@@ -55,8 +36,20 @@ Imports SkyEditor.ROMEditor.Utilities
     End Sub
 
     <TestInitialize()> Public Sub TestInit()
-        provider = New PhysicalIOProvider
-        UnpackFiles(provider)
+        Try
+            Using md5 As New MD5CryptoServiceProvider
+                Dim hash = md5.ComputeHash(My.Resources.brt_u)
+                If Not hash.SequenceEqual(My.Resources.BRT_U_MD5) Then
+                    Assert.Inconclusive("Incorrect test ROM specified.  Should be a trimmed North America PMD: Blue Rescue Team ROM.")
+                End If
+            End Using
+
+            Dim nds As New NdsRom
+            nds.OpenFile(romFilename, New PhysicalIOProvider()).Wait()
+            provider = nds
+        Catch ex As Exception
+            Assert.Inconclusive("Failed to set up.  Exception message: " & ex.Message)
+        End Try
     End Sub
 
     <TestCleanup> Public Sub Cleanup()
@@ -64,14 +57,14 @@ Imports SkyEditor.ROMEditor.Utilities
     End Sub
 
     <TestMethod> <TestCategory(Category)> <TestCategory(TestHelpers.AutomatedTestCategory)> Public Sub SBinFileFormat()
-        Dim dungeon = TestHelpers.GetAndTestFile(Of SBin)(Path.Combine(romDir, "data", "dungeon.sbin"), True, provider)
-        Dim effect = TestHelpers.GetAndTestFile(Of SBin)(Path.Combine(romDir, "data", "effect.sbin"), True, provider)
-        Dim ground = TestHelpers.GetAndTestFile(Of SBin)(Path.Combine(romDir, "data", "ground.sbin"), True, provider)
-        Dim monster = TestHelpers.GetAndTestFile(Of SBin)(Path.Combine(romDir, "data", "monster.sbin"), True, provider)
-        Dim ornament = TestHelpers.GetAndTestFile(Of SBin)(Path.Combine(romDir, "data", "ornament.sbin"), True, provider)
-        Dim sample = TestHelpers.GetAndTestFile(Of SBin)(Path.Combine(romDir, "data", "sample.sbin"), True, provider)
-        Dim system = TestHelpers.GetAndTestFile(Of SBin)(Path.Combine(romDir, "data", "system.sbin"), True, provider)
-        Dim titlemenu = TestHelpers.GetAndTestFile(Of SBin)(Path.Combine(romDir, "data", "titlemenu.sbin"), True, provider)
+        Dim dungeon = TestHelpers.GetAndTestFile(Of SBin)("/data/dungeon.sbin", True, provider)
+        Dim effect = TestHelpers.GetAndTestFile(Of SBin)("/data/effect.sbin", True, provider)
+        Dim ground = TestHelpers.GetAndTestFile(Of SBin)("/data/ground.sbin", True, provider)
+        Dim monster = TestHelpers.GetAndTestFile(Of SBin)("/data/monster.sbin", True, provider)
+        Dim ornament = TestHelpers.GetAndTestFile(Of SBin)("/data/ornament.sbin", True, provider)
+        Dim sample = TestHelpers.GetAndTestFile(Of SBin)("/data/sample.sbin", True, provider)
+        Dim system = TestHelpers.GetAndTestFile(Of SBin)("/data/system.sbin", True, provider)
+        Dim titlemenu = TestHelpers.GetAndTestFile(Of SBin)("/data/titlemenu.sbin", True, provider)
     End Sub
 
     <TestMethod> <TestCategory(Category)> <TestCategory(TestHelpers.AutomatedTestCategory)> Public Sub MonsterKaoTest()
@@ -80,7 +73,7 @@ Imports SkyEditor.ROMEditor.Utilities
         Dim repackFilename = "repack-monster.sbin"
         'Extract
         Dim monster1 As New SBin
-        monster1.OpenFile(Path.Combine(romDir, "data", "monster.sbin"), provider).Wait()
+        monster1.OpenFile("/data/monster.sbin", provider).Wait()
 
         For Each item In monster1.Files.Where(Function(x) x.Key.StartsWith("kao"))
             Using kao As New KaoFile

--- a/Tests/SkyEditor.ROMEditor.IntegrationTests/CombinedExplorersRescueTests.vb
+++ b/Tests/SkyEditor.ROMEditor.IntegrationTests/CombinedExplorersRescueTests.vb
@@ -9,20 +9,20 @@ Imports SkyEditor.ROMEditor.MysteryDungeon.Rescue
 
     Dim provider As IIOProvider
 
-    <TestInitialize> Public Sub TestInit()
-        provider = New PhysicalIOProvider
-        If Not BRTUTests.IsTestInitialized Then
-            BRTUTests.UnpackFiles(provider)
-        End If
-        If Not EoSUTests.IsTestInitialized Then
-            EoSUTests.UnpackFiles(provider)
-        End If
-    End Sub
+    '<TestInitialize> Public Sub TestInit()
+    '    provider = New PhysicalIOProvider
+    '    If Not BRTUTests.IsTestInitialized Then
+    '        BRTUTests.UnpackFiles(provider)
+    '    End If
+    '    If Not EoSUTests.IsTestInitialized Then
+    '        EoSUTests.UnpackFiles(provider)
+    '    End If
+    'End Sub
 
-    <TestCleanup> Public Sub TestCleanup()
-        BRTUTests.CleanupFiles(provider)
-        EoSUTests.CleanupFiles(provider)
-    End Sub
+    '<TestCleanup> Public Sub TestCleanup()
+    '    BRTUTests.CleanupFiles(provider)
+    '    EoSUTests.CleanupFiles(provider)
+    'End Sub
 
     '<TestMethod> <TestCategory(TestCategory)> <TestCategory(TestHelpers.ManualTestCategory)> Public Sub CopyEosToBRTKaomado()
     '    Dim monster As New SBin

--- a/Tests/SkyEditor.ROMEditor.IntegrationTests/EoSUTests.vb
+++ b/Tests/SkyEditor.ROMEditor.IntegrationTests/EoSUTests.vb
@@ -11,49 +11,19 @@ Imports SkyEditor.ROMEditor.Utilities
 
     Private Const EosTestCategory As String = "EOS (U) Files"
 
-    'Files for all tests
-    Private Const romFilename As String = "eos-u.nds"
-    Public Const romDir As String = "extracted-EOS-U"
-
     Dim provider As IIOProvider
 
-    ''' <summary>
-    ''' Determines whether or not the test has been initialized
-    ''' </summary>
-    ''' <remarks>This is not thread safe, and assumes tests are initialized or cleaned sequentially.</remarks>
-    Public Shared Function IsTestInitialized() As Boolean
-        Return Directory.Exists(romDir)
-    End Function
-
-    Public Shared Sub CleanupFiles(provider As IIOProvider)
-        If provider.FileExists(romFilename) Then
-            provider.DeleteFile(romFilename)
-        End If
-        If provider.DirectoryExists(romDir) Then
-            provider.DeleteDirectory(romDir)
-        End If
-    End Sub
-
-
     <TestInitialize()> Public Sub TestInit()
-        Try
-            Using md5 As New MD5CryptoServiceProvider
-                Dim hash = md5.ComputeHash(My.Resources.eos_u)
-                If Not hash.SequenceEqual(My.Resources.EoS_U_MD5) Then
-                    Assert.Inconclusive("Incorrect test ROM specified.  Should be a trimmed North America PMD: Explorers of Sky ROM.")
-                End If
-            End Using
+        Using md5 As New MD5CryptoServiceProvider
+            Dim hash = md5.ComputeHash(My.Resources.eos_u)
+            If Not hash.SequenceEqual(My.Resources.EoS_U_MD5) Then
+                Assert.Fail("Incorrect test ROM specified.  Should be a trimmed North America PMD: Explorers of Sky ROM.")
+            End If
+        End Using
 
-            Dim nds As New NdsRom
-            nds.OpenFile(romFilename, New PhysicalIOProvider()).Wait()
-            provider = nds
-        Catch ex As Exception
-            Assert.Inconclusive("Failed to set up.  Exception message: " & ex.Message)
-        End Try
-    End Sub
-
-    <TestCleanup> Public Sub Cleanup()
-        CleanupFiles(provider)
+        Dim nds As New NdsRom
+        nds.OpenFileInMemory(My.Resources.eos_u).Wait()
+        provider = nds
     End Sub
 
     <TestMethod> <TestCategory(EosTestCategory)> <TestCategory(TestHelpers.AutomatedTestCategory)> Public Sub Overlay13()
@@ -252,7 +222,7 @@ Imports SkyEditor.ROMEditor.Utilities
 
 #Region "Language Strings"
     <TestMethod> <TestCategory(EosTestCategory)> <TestCategory(TestHelpers.AutomatedTestCategory)> Public Sub LanguageString_FileOpenAndSave()
-        Using testFile = TestHelpers.GetAndTestFile(Of LanguageString)(Path.Combine(romDir, "data", "message", "text_e.str"), True, provider)
+        Using testFile = TestHelpers.GetAndTestFile(Of LanguageString)(Path.Combine("data", "message", "text_e.str"), True, provider)
             'Ensure data is at least somewhat valid
             Assert.AreEqual(18451, testFile.Items.Count, "Incorrect number of items")
         End Using

--- a/Tests/SkyEditor.ROMEditor.IntegrationTests/EoSUTests.vb
+++ b/Tests/SkyEditor.ROMEditor.IntegrationTests/EoSUTests.vb
@@ -25,25 +25,6 @@ Imports SkyEditor.ROMEditor.Utilities
         Return Directory.Exists(romDir)
     End Function
 
-    Public Shared Sub UnpackFiles(provider As IIOProvider)
-        Try
-            Using md5 As New MD5CryptoServiceProvider
-                Dim hash = md5.ComputeHash(My.Resources.eos_u)
-                If Not hash.SequenceEqual(My.Resources.EoS_U_MD5) Then
-                    Assert.Inconclusive("Incorrect test ROM specified.  Should be a trimmed North America PMD: Explorers of Sky ROM.")
-                End If
-            End Using
-
-            provider.WriteAllBytes(romFilename, My.Resources.eos_u)
-            Using nds As New NdsRom
-                nds.OpenFile(romFilename, provider).Wait()
-                nds.Unpack(romDir, provider).Wait()
-            End Using
-        Catch ex As Exception
-            Assert.Inconclusive("Failed to set up.  Exception message: " & ex.Message)
-        End Try
-    End Sub
-
     Public Shared Sub CleanupFiles(provider As IIOProvider)
         If provider.FileExists(romFilename) Then
             provider.DeleteFile(romFilename)
@@ -55,8 +36,20 @@ Imports SkyEditor.ROMEditor.Utilities
 
 
     <TestInitialize()> Public Sub TestInit()
-        provider = New PhysicalIOProvider
-        UnpackFiles(provider)
+        Try
+            Using md5 As New MD5CryptoServiceProvider
+                Dim hash = md5.ComputeHash(My.Resources.eos_u)
+                If Not hash.SequenceEqual(My.Resources.EoS_U_MD5) Then
+                    Assert.Inconclusive("Incorrect test ROM specified.  Should be a trimmed North America PMD: Explorers of Sky ROM.")
+                End If
+            End Using
+
+            Dim nds As New NdsRom
+            nds.OpenFile(romFilename, New PhysicalIOProvider()).Wait()
+            provider = nds
+        Catch ex As Exception
+            Assert.Inconclusive("Failed to set up.  Exception message: " & ex.Message)
+        End Try
     End Sub
 
     <TestCleanup> Public Sub Cleanup()
@@ -64,7 +57,7 @@ Imports SkyEditor.ROMEditor.Utilities
     End Sub
 
     <TestMethod> <TestCategory(EosTestCategory)> <TestCategory(TestHelpers.AutomatedTestCategory)> Public Sub Overlay13()
-        Dim testFile = TestHelpers.GetAndTestFile(Of Overlay13)(Path.Combine(romDir, "overlay", "overlay_0013.bin"), True, provider)
+        Dim testFile = TestHelpers.GetAndTestFile(Of Overlay13)("/overlay/overlay_0013.bin", True, provider)
         'Starters
         'Bulbasaur
         Assert.AreEqual(CUShort(1), testFile.LonelyMale, "Incorrect starter for Lonely Male")
@@ -164,42 +157,42 @@ Imports SkyEditor.ROMEditor.Utilities
     End Sub
 
     <TestMethod> <TestCategory(EosTestCategory)> <TestCategory(TestHelpers.AutomatedTestCategory)> Public Sub item_p()
-        Using testFile = TestHelpers.GetAndTestFile(Of item_p)(Path.Combine(romDir, "data", "balance", "item_p.bin"), True, provider)
+        Using testFile = TestHelpers.GetAndTestFile(Of item_p)("/data/balance/item_p.bin", True, provider)
             'Ensure data is at least somewhat valid
             Assert.AreEqual(1400, testFile.Items.Count, "Incorrect number of items")
         End Using
     End Sub
 
     <TestMethod> <TestCategory(EosTestCategory)> <TestCategory(TestHelpers.AutomatedTestCategory)> Public Sub item_s_p()
-        Using testFile = TestHelpers.GetAndTestFile(Of item_s_p)(Path.Combine(romDir, "data", "balance", "item_s_p.bin"), True, provider)
+        Using testFile = TestHelpers.GetAndTestFile(Of item_s_p)("/data/balance/item_s_p.bin", True, provider)
             'Ensure data is at least somewhat valid
             Assert.AreEqual(956, testFile.Items.Count, "Incorrect number of items")
         End Using
     End Sub
 
     <TestMethod> <TestCategory(EosTestCategory)> <TestCategory(TestHelpers.AutomatedTestCategory)> Public Sub mappa_s()
-        Using testFile = TestHelpers.GetAndTestFile(Of mappa)(Path.Combine(romDir, "data", "balance", "mappa_s.bin"), False, provider)
+        Using testFile = TestHelpers.GetAndTestFile(Of mappa)("/data/balance/mappa_s.bin", False, provider)
             'Ensure data is at least somewhat valid
             Assert.AreEqual(100, testFile.Dungeons.Count, "Incorrect number of items")
         End Using
     End Sub
 
     <TestMethod> <TestCategory(EosTestCategory)> <TestCategory(TestHelpers.AutomatedTestCategory)> Public Sub mappa_t()
-        Using testFile = TestHelpers.GetAndTestFile(Of mappa)(Path.Combine(romDir, "data", "balance", "mappa_t.bin"), False, provider)
+        Using testFile = TestHelpers.GetAndTestFile(Of mappa)("/data/balance/mappa_t.bin", False, provider)
             'Ensure data is at least somewhat valid
             Assert.AreEqual(64, testFile.Dungeons.Count, "Incorrect number of items")
         End Using
     End Sub
 
     <TestMethod> <TestCategory(EosTestCategory)> <TestCategory(TestHelpers.AutomatedTestCategory)> Public Sub mappa_y()
-        Using testFile = TestHelpers.GetAndTestFile(Of mappa)(Path.Combine(romDir, "data", "balance", "mappa_y.bin"), False, provider)
+        Using testFile = TestHelpers.GetAndTestFile(Of mappa)("data/balance/mappa_y.bin", False, provider)
             'Ensure data is at least somewhat valid
             Assert.AreEqual(64, testFile.Dungeons.Count, "Incorrect number of items")
         End Using
     End Sub
 
     <TestMethod> <TestCategory(EosTestCategory)> <TestCategory(TestHelpers.AutomatedTestCategory)> Public Sub waza_p()
-        Using testFile = TestHelpers.GetAndTestFile(Of waza_p)(Path.Combine(romDir, "data", "balance", "waza_p.bin"), False, provider)
+        Using testFile = TestHelpers.GetAndTestFile(Of waza_p)("data/balance/waza_p.bin", False, provider)
             'Ensure data is at least somewhat valid
             Assert.AreEqual(559, testFile.Moves.Count, "Incorrect number of moves")
             Assert.AreEqual(553, testFile.PokemonLearnsets.Count, "Incorrect number of Pokemon moveset data")
@@ -214,7 +207,7 @@ Imports SkyEditor.ROMEditor.Utilities
     <TestMethod> <TestCategory(EosTestCategory)> <TestCategory(TestHelpers.AutomatedTestCategory)> Public Sub Kaomado()
         'Extract
         Dim kao1 As New Kaomado
-        kao1.OpenFile(Path.Combine(romDir, "data", "font", "kaomado.kao"), provider).Wait()
+        kao1.OpenFile("/data/font/kaomado.kao", provider).Wait()
 
         'Pack
         Dim kao2 As New Kaomado

--- a/Tests/SkyEditor.ROMEditor.IntegrationTests/SkyEditor.ROMEditor.IntegrationTests.vbproj
+++ b/Tests/SkyEditor.ROMEditor.IntegrationTests/SkyEditor.ROMEditor.IntegrationTests.vbproj
@@ -68,7 +68,7 @@
       <HintPath>..\..\packages\DotNet3dsToolkit.2.0.0-CI51\lib\net462\DotNet3dsToolkit.dll</HintPath>
     </Reference>
     <Reference Include="DotNetNdsToolkit, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetNdsToolkit.2.0.0-CI114\lib\net462\DotNetNdsToolkit.dll</HintPath>
+      <HintPath>..\..\packages\DotNetNdsToolkit.2.0.0-CI117\lib\net462\DotNetNdsToolkit.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Tests/SkyEditor.ROMEditor.IntegrationTests/packages.config
+++ b/Tests/SkyEditor.ROMEditor.IntegrationTests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Crc32.NET" version="1.2.0" targetFramework="net462" />
   <package id="DotNet3dsToolkit" version="2.0.0-CI51" targetFramework="net462" />
-  <package id="DotNetNdsToolkit" version="2.0.0-CI114" targetFramework="net462" />
+  <package id="DotNetNdsToolkit" version="2.0.0-CI117" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="SkyEditor.Core" version="4.1.0-CI166" targetFramework="net462" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net462" />


### PR DESCRIPTION
Also makes the tests simpler by bypassing the filesystem for ROM files. Some graphics tests may still use the file system.